### PR TITLE
 Move divider tokens from foundations to component

### DIFF
--- a/src/Divider/Tokens/tokens.ts
+++ b/src/Divider/Tokens/tokens.ts
@@ -1,0 +1,9 @@
+import { inube } from "@inubekit/foundations";
+
+const tokens = {
+  stroke: {
+    color: inube.palette.neutral.N40,
+  },
+};
+
+export { tokens };

--- a/src/Divider/styles.js
+++ b/src/Divider/styles.js
@@ -1,11 +1,10 @@
 import styled from "styled-components";
-import { inube } from "@inubekit/foundations";
+import { tokens } from "./Tokens/tokens";
 
 const StyledDivider = styled.hr`
   border: 0;
   border-top: 2px ${({ $dashed }) => ($dashed ? "dashed" : "solid")}
-    ${({ theme }) =>
-      theme?.divider?.stroke?.color || inube.divider.stroke.color};
+    ${({ theme }) => theme?.divider?.stroke?.color || tokens.stroke.color};
   width: 100%;
   margin: 0;
 `;


### PR DESCRIPTION
This PR moves the divider tokens from the foundations folder to the component folder, updating all relevant imports to align with the new structure and ensuring that components are referencing the correct token paths. This enhances the organization, maintainability, and clarity of the token usage across the codebase.